### PR TITLE
fix: overrides incorrect documentation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,23 @@ require 'evergarden'.setup {
 
 Overrides can take all options passed to `vim.api.nvim_set_hl()`.
 
+> [!note]
+> - Ensure that `fg` (foreground color) and `gb` (background color) are correctly positioned as the first and second elements in the table, respectively.
+> - Confirm that `fg` and `gb` are arrays, with the first element representing the GUI color, and the second element representing the CTERM (Color Terminal) color, if specified.
+
 ```lua
 require 'evergarden'.setup {
-    overrides = {
-        'Normal' = { '#fddce3', '#1d2021' } -- { 'fg', 'bg', bold = bool, italic = bool, ... }
+  overrides = {
+    Normal = {
+      { '#fddce3', 8 }, -- GUI color and cterm color for 'fg'
+      { '#1d2021' },    -- GUI color for 'bg'
+
+      -- Additional highlight options can be included here
+
+      bold = true,
+      italic = false,
     },
+  },
 }
 ```
 


### PR DESCRIPTION
There are one incorrect documentation in overrides section, which might confuse those who're trying to override.

The documentation suggest to configure the fg and bg by the way showing below:
```lua
require 'evergarden'.setup {
    overrides = {
        'Normal' = { '#fddce3', '#1d2021' } -- { 'fg', 'bg', bold = bool, italic = bool, ... }
    },
}
```

But the code handling fg and bg as an array
```lua
---@param group string
---@param colors evergarden.types.colorspec
local function set_hi(group, colors)
    if not vim.tbl_isempty(colors) then
        ---@type vim.api.keyset.highlight
        local color = colors
        color.fg = colors[1] and colors[1][1] or 'NONE'
        color.bg = colors[2] and colors[2][1] or 'NONE'
        color.ctermfg = colors[1] and colors[1][2] or 'NONE'
        color.ctermbg = colors[2] and colors[2][2] or 'NONE'
        color[1] = nil
        color[2] = nil
        vim.api.nvim_set_hl(0, group, color)
    end
end
```

This pull request tries to clarify the documentation for those who're coming later.

Thank you for your effort and your the beautiful neovim theme.
